### PR TITLE
Feat: pip size config

### DIFF
--- a/android/src/main/java/com/rnpip/RnPipModule.java
+++ b/android/src/main/java/com/rnpip/RnPipModule.java
@@ -21,6 +21,8 @@ public class RnPipModule extends ReactContextBaseJavaModule {
   public static Boolean ENABLE_AUTO_PIP_MODE = false;
   private static DeviceEventManagerModule.RCTDeviceEventEmitter eventEmitter = null;
 
+  private static Rational pipRatio;
+
   ReactApplicationContext reactApplicationContext;
   public static ReactApplicationContext _reactApplicationContext;
 
@@ -34,6 +36,13 @@ public class RnPipModule extends ReactContextBaseJavaModule {
     super(reactContext);
     this.reactApplicationContext = reactContext;
     _reactApplicationContext = reactContext;
+
+    this.pipRatio = new Rational(380, 214);
+  }
+
+  @ReactMethod
+  public void setDisplay(int width, int height){
+    this.pipRatio = new Rational(width, height);
   }
 
   @Override
@@ -71,13 +80,8 @@ public class RnPipModule extends ReactContextBaseJavaModule {
       return;
     }
 
-    // 300, 214
-    int ratWidth = 380;
-    int ratHeight = 214;
-
     PictureInPictureParams.Builder pipBuilder = new PictureInPictureParams.Builder();
-    Rational ratio = new Rational(ratWidth, ratHeight);
-    pipBuilder.setAspectRatio(ratio);
+    pipBuilder.setAspectRatio(RnPipModule.pipRatio);
     PictureInPictureParams params = pipBuilder.build();
 
     _reactApplicationContext.getCurrentActivity().enterPictureInPictureMode(params);
@@ -90,7 +94,7 @@ public class RnPipModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void enterPictureInPictureMode(int width, int height) {
+  public void enterPictureInPictureMode() {
      if(isInPipMode()){
        return;
      }
@@ -104,13 +108,8 @@ public class RnPipModule extends ReactContextBaseJavaModule {
       return;
     }
 
-   // 300, 214
-    int ratWidth = width > 0 ? width : 380;
-    int ratHeight = height > 0 ? height : 214;
-
     PictureInPictureParams.Builder pipBuilder = new PictureInPictureParams.Builder();
-    Rational ratio = new Rational(ratWidth, ratHeight);
-    pipBuilder.setAspectRatio(ratio);
+    pipBuilder.setAspectRatio(RnPipModule.pipRatio);
     PictureInPictureParams params = pipBuilder.build();
 
     reactApplicationContext.getCurrentActivity().enterPictureInPictureMode(params);

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -10,6 +10,13 @@ export default function App() {
   const inPipMode = RnPipHandler.usePipModeListener();
   const [autoPipMode, setAutoPipMode] = React.useState(true);
 
+  const handleEnterPipMode = () => {
+    RnPipHandler.setDisplay(214, 380);
+
+    // RnPipHandler.enterPictureInPictureMode(); // or
+    enterPictureInPictureMode();
+  };
+
   React.useEffect(() => {
     enableAutoPipMode(autoPipMode);
   }, [autoPipMode]);
@@ -25,10 +32,7 @@ export default function App() {
   return (
     <View style={styles.container}>
       <View style={styles.box}>
-        <Button
-          onPress={() => enterPictureInPictureMode()}
-          title="Enter pip Mode"
-        />
+        <Button onPress={handleEnterPipMode} title="Enter pip Mode" />
         <Text>Pip Mode {inPipMode.toString()}</Text>
       </View>
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -74,7 +74,12 @@ function isAndroid() {
   return Platform.OS === 'android';
 }
 
+export const setDisplay = (width: number, height: number) => {
+  RnPip.setDisplay(width, height);
+};
+
 export default {
+  setDisplay,
   enterPictureInPictureMode,
   usePipModeListener,
   enableAutoPipMode,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,29 +27,25 @@ export function multiply(a: number, b: number): Promise<number> {
   return RnPip.multiply(a, b);
 }
 
-export function enterPictureInPictureMode(width?: number, height?: number) {
-  if (Platform.OS !== 'android') {
+export function enterPictureInPictureMode() {
+  if (!isAndroid()) {
     return;
   }
 
-  return RnPip.enterPictureInPictureMode(
-    width ? Math.floor(width) : 0,
-    height ? Math.floor(height) : 0
-  );
+  return RnPip.enterPictureInPictureMode();
 }
 
-const PipEventEmitter =
-  Platform.OS === 'android' ? new NativeEventEmitter(RnPip) : null;
+const PipEventEmitter = isAndroid() ? new NativeEventEmitter(RnPip) : null;
 
 export function onPipModeChanged(listener: (isModeEnabled: boolean) => void) {
-  if (Platform.OS !== 'android') {
+  if (!isAndroid()) {
     return;
   }
   return PipEventEmitter?.addListener('PIP_MODE_CHANGE', listener);
 }
 
 export function enableAutoPipMode(enable: boolean) {
-  if (Platform.OS !== 'android') {
+  if (!isAndroid()) {
     return;
   }
   RnPip.enableAutoPipMode(enable);
@@ -59,7 +55,7 @@ export function usePipModeListener(): boolean {
   const [isModeEnabled, setIsPipModeEnabled] = useState<boolean>(false);
 
   useEffect(() => {
-    if (Platform.OS !== 'android') {
+    if (!isAndroid()) {
       return;
     }
 
@@ -72,6 +68,10 @@ export function usePipModeListener(): boolean {
   }, []);
 
   return isModeEnabled;
+}
+
+function isAndroid() {
+  return Platform.OS === 'android';
 }
 
 export default {


### PR DESCRIPTION
This PR targets setting display size from the picture-in-picture view of the app.

> NOTE: [`pipRatio`](https://github.com/micaiah-effiong/rn-pip/blob/365be1a/android/src/main/java/com/rnpip/RnPipModule.java#L24) is set as a private static property on  `RnPipModule` to share state with [auto pip mode](https://github.com/micaiah-effiong/rn-pip/blob/365be1a/android/src/main/java/com/rnpip/RnPipModule.java#L69)